### PR TITLE
Content Updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,34 +101,37 @@ tokio = { version = "0.2", features = ["full"] }
       </pre>
       <p>Then, in your <strong>src/main.rs</strong>:</p>
       <pre data-enlighter-language="rust">
-use ipfs::{IpfsOptions, IpfsPath, TestTypes, UninitializedIpfs};
-use std::convert::TryFrom;
+use futures::pin_mut;
+use futures::stream::StreamExt; // needed for StreamExt::next
+use ipfs::{Ipfs, IpfsOptions, IpfsPath, TestTypes, UninitializedIpfs};
 use std::process::exit;
-use tokio::prelude::*;
-use tokio::stream::StreamExt;
+use tokio::io::AsyncWriteExt;
 
 #[tokio::main]
 async fn main() {
-    // Load in some default testing options
-    let options = IpfsOptions::inmemory_with_generated_keys();
+    // Initialize an in-memory repo and start a daemon.
+    let opts = IpfsOptions::inmemory_with_generated_keys();
+    let (ipfs, fut): (Ipfs&lt;TestTypes&gt;, _) = UninitializedIpfs::new(opts).start().await.unwrap();
 
-    // TODO: Bootstrap
+    // Spawn the background task
+    tokio::task::spawn(fut);
 
-    // Start daemon and initialize repo
-    let (ipfs, fut): (Ipfs&lt;TestTypes&gt;, _) = UninitializedIpfs::new(options).start().await.unwrap();
+    // Restore the bootstrappers for the global swarm
+    ipfs.restore_bootstrappers().await.unwrap();
 
-    tokio::spawn(fut);
-
-    let path = IpfsPath::try_from("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/readme").unwrap();
+    // Get the IPFS README
+    let path = "/ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme"
+        .parse::&lt;IpfsPath&gt;()
+        .unwrap();
 
     let stream = ipfs.cat_unixfs(path, None).await.unwrap_or_else(|e| {
         eprintln!("Error: {}", e);
         exit(1);
     });
 
-    tokio::pin!(stream);
-
+    pin_mut!(stream);
     let mut stdout = tokio::io::stdout();
+
     loop {
         match stream.next().await {
             Some(Ok(bytes)) =&gt; {

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@ async fn main() {
     // TODO: Bootstrap
 
     // Start daemon and initialize repo
-    let (ipfs, fut): (Ipfs<TestTypes>, _) = UninitializedIpfs::new(options).start().await.unwrap();
+    let (ipfs, fut): (Ipfs&lt;TestTypes&gt;, _) = UninitializedIpfs::new(options).start().await.unwrap();
 
     tokio::spawn(fut);
 

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
       <pre data-enlighter-language="toml">
 [dependencies]
 futures = { default-features = false, version = "0.3.5", features = ["alloc", "std"] }
-ipfs = "0.2.0"
+ipfs = "0.2.1"
 tokio = { version = "0.2", features = ["full"] }
       </pre>
       <p>Then, in your <strong>src/main.rs</strong>:</p>

--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
       </p>
       <pre data-enlighter-language="toml">
 [dependencies]
+futures = { default-features = false, version = "0.3.5", features = ["alloc", "std"] }
 ipfs = "0.2.0"
 tokio = { version = "0.2", features = ["full"] }
       </pre>

--- a/index.html
+++ b/index.html
@@ -87,22 +87,8 @@
 
     <section id="getting-started">
       <h2>Getting Started</h2>
-      <div id="cargo-install">
-        <p>Install via Cargo, initialize, and run the daemon</p>
-        <pre data-enlighter-language="shell">
-$ cargo install ipfs-http
-$ ipfs-http init --bits 4096 --profile test
-$ ipfs-http daemon &amp;
-...
-API listening on /ip4/127.0.0.1/tcp/33801
-daemon is running
-
-$ curl 127.0.0.1:33801/api/v0/id | jq .ID
-"QmRJUsPnZH5Pn3dBRDDiEV1JBjLB1KTeFhspYwFVk8czS1"
-        </pre>
-      </div>
+      <p>Using IPFS in your Rust code is simple and only requires a few dependencies:</p>
       <div>
-        <p>...or use it in your Rust code</p>
         <pre data-enlighter-language="rust">
 use ipfs::{IpfsOptions, IpfsPath, TestTypes, UninitializedIpfs};
 use std::convert::TryFrom;

--- a/index.html
+++ b/index.html
@@ -182,18 +182,17 @@ async fn main() {
 
     <footer>
       <div>
-        <span>Copyright © 2020 Equilibrium</span>
-        <span>Rust IPFS is dual licensed under the MIT / Apache License.</span>
+        <small>This website copyright © 2020 Equilibrium</small>
+        <small>
+          The Rust logo and wordmark are trademarks owned and protected by the Mozilla Foundation
+        </small>
       </div>
-      <br />
       <div>
-        The Rust logo and wordmark are trademarks owned and protected by
-        the Mozilla Foundation.
-      </div>
-      <br />
-      <div>
-        The Rust and Cargo logos (bitmap and vector) are owned by Mozilla
-        and distributed under the terms of the Creative Commons Attribution license (CC-BY).</a>
+        <small>Rust IPFS is dual licensed under the MIT / Apache License</small>
+        <small>
+          The Rust and Cargo logos (bitmap and vector) are owned by Mozilla and distributed under
+          the terms of the Creative Commons Attribution license (CC-BY)
+        </small>
       </div>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -41,12 +41,9 @@
         </h1>
 
         <nav>
-          <a target="_blank" href="https://docs.rs/ipfs">Docs</a>
+          <a target="_blank" href="https://docs.rs/ipfs">Documentation</a>
           <a target="_blank" href="https://github.com/rs-ipfs/rust-ipfs">GitHub</a>
-          <a target="_blank" href="https://medium.com/equilibriumco/rustipfs/home">Blog</a>
         </nav>
-
-        <a class="cta" href="#support">Support</a>
       </div>
     </header>
 

--- a/index.html
+++ b/index.html
@@ -90,33 +90,37 @@
 
     <section id="getting-started">
       <h2>Getting Started</h2>
-      <p>Using IPFS in your Rust code is simple and only requires a few dependencies:</p>
-      <div>
-        <pre data-enlighter-language="rust">
+      <p>
+        First, add <code>ipfs</code> and <code>tokio</code>
+        to your <strong>Cargo.toml</strong> file:
+      </p>
+      <pre data-enlighter-language="toml">
+[dependencies]
+ipfs = "0.2.0"
+tokio = { version = "0.2", features = ["full"] }
+      </pre>
+      <p>Then, in your <strong>src/main.rs</strong>:</p>
+      <pre data-enlighter-language="rust">
 use ipfs::{IpfsOptions, IpfsPath, TestTypes, UninitializedIpfs};
 use std::convert::TryFrom;
 use std::process::exit;
 use tokio::prelude::*;
 use tokio::stream::StreamExt;
 
-// quick-start dependencies:
-// ipfs = { git = "https://github.com/rs-ipfs/rust-ipfs.git" }
-// tokio = { version = "0.2", features = ["full"] }
-
 #[tokio::main]
 async fn main() {
-    let options = IpfsOptions::default();
+    // Load in some default testing options
+    let options = IpfsOptions::inmemory_with_generated_keys();
+
+    // TODO: Bootstrap
 
     // Start daemon and initialize repo
-    let (ipfs, fut) = UninitializedIpfs::<TestTypes>::new(options, None)
-        .await
-        .start()
-        .await
-        .unwrap();
+    let (ipfs, fut): (Ipfs<TestTypes>, _) = UninitializedIpfs::new(options).start().await.unwrap();
 
     tokio::spawn(fut);
 
     let path = IpfsPath::try_from("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/readme").unwrap();
+
     let stream = ipfs.cat_unixfs(path, None).await.unwrap_or_else(|e| {
         eprintln!("Error: {}", e);
         exit(1);
@@ -138,8 +142,7 @@ async fn main() {
         }
     }
 }
-        </pre>
-      </div>
+      </pre>
       <a class="top" href="#">▲</a>
     </section>
 
@@ -201,7 +204,7 @@ async fn main() {
 
     <script src="./vendor/enlighterjs-3.0.0/enlighterjs.min.js"></script>
     <script type="text/javascript">
-      EnlighterJS.init('pre', 'code', {
+      EnlighterJS.init('pre', null, {
         language : 'rust',
         theme: 'droide',
         indent : 4

--- a/index.html
+++ b/index.html
@@ -53,7 +53,10 @@
         and the decentralized power of <em>IPFS</em>.
       </h2>
       <h2>Together at last.</h2>
-      <a class="cta" href="#getting-started">Get Started</a>
+
+      <div class="cta">
+        <a class="primary" href="#getting-started">Get Started</a>
+      </div>
     </section>
 
     <section id="features">

--- a/styles.css
+++ b/styles.css
@@ -92,12 +92,29 @@ img { max-width: 100%; }
 p { font-size: 1.2rem; }
 a { color: var(--logo-dark); text-decoration: none; font-weight: bold; }
 
-body > header > div, body > section > div, body > footer > div {
+body > header > div, body > section > div, body > footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
   max-width: 1024px;
   margin: 0 auto;
+}
+
+body > footer {
+  align-items: flex-start;
+}
+
+body > footer > div {
+  max-width: 50%;
+}
+
+body > footer > div > small {
+  display: block;
+  font-size: 0.75em;
+}
+
+body > footer > div:last-child {
+  text-align: right;
 }
 
 body > header, body > footer {

--- a/styles.css
+++ b/styles.css
@@ -172,24 +172,29 @@ section#hero > h2 {
   max-width: 26rem;
   text-align: center;
   text-shadow: 1px 1px 2px var(--logo-dark);
-  text-shadow: 0px 0px 30px var(--off-white);
+  text-shadow: 0px 0px 30px var(--logo-ultra-light);
 }
 section#hero > h2 > em {
   font-style: inherit;
 }
 
-.cta {
-  text-decoration: none;
-  font-family: "Cabin Bold", sans-serif;
-  color: var(--off-black);
-  font-weight: bold;
+.cta > a {
   font-size: 1.25rem;
-  background: var(--accent2);
-  background-blend-mode: overlay;
-  border: 2px solid var(--off-white);
+  margin: 0 0.9rem;
   border-radius: 0.25rem;
   padding: 0.5rem;
-  margin: 0 0.5rem;
+  background-blend-mode: overlay;
+  font-weight: bold;
+  color: var(--off-black);
+  text-decoration: none;
+  background: var(--logo-ultra-light);
+}
+.cta > a:hover {
+  color: black;
+  box-shadow: 0px 0px 50px var(--logo-highlight);
+}
+.cta > a.primary {
+  background: var(--accent2);
 }
 
 body > section > h2 {

--- a/styles.css
+++ b/styles.css
@@ -86,21 +86,26 @@ body {
   font-family: "Cabin", sans-serif;
 }
 
+/* Inline Styles */
+
 h1,h2 { font-family: "Cabin Bold", sans-serif }
 h3,h4,h5,h6 { font-family: "Cabin", sans-serif }
 img { max-width: 100%; }
 p { font-size: 1.2rem; }
 a { color: var(--logo-dark); text-decoration: none; font-weight: bold; }
+code { background: var(--value1); font-size: 90%; padding: 0 0.2rem; }
 
-body > header > div, body > section > div, body > footer {
+
+body > header > div, body > section > div {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  max-width: 1024px;
-  margin: 0 auto;
 }
 
 body > footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   align-items: flex-start;
 }
 
@@ -195,8 +200,12 @@ section#hero > h2 > em {
   background: var(--accent2);
 }
 
-body > section > h2 {
-  margin: 0 auto;
+body > section > h2,
+body > header > div,
+body > section > div,
+body > section > p {
+  margin-left: auto;
+  margin-right: auto;
   max-width: 1024px;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -83,7 +83,7 @@ body {
   margin: 0;
   background: var(--off-white);
   color: var(--off-black);
-  font-family: Georgia,'Times New Roman',serif;
+  font-family: "Cabin", sans-serif;
 }
 
 h1,h2 { font-family: "Cabin Bold", sans-serif }
@@ -121,7 +121,6 @@ body > header, body > footer {
   padding: 1rem;
   background: var(--off-black);
   color: var(--off-white);
-  font-family: "Cabin", sans-serif;
 }
 
 @media (max-width: 600px) {
@@ -150,7 +149,6 @@ body > header > div > h1 > a > img {
 
 body > header a {
   text-decoration: none;
-  font-family: Cabin, sans-serif;
   color: var(--off-white);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -184,14 +184,8 @@ body > section {
   padding: 1rem;
   background: var(--page-background);
 }
-
 body > section#getting-started > div {
-  max-width: 1024px;
   margin: 0 auto;
-  display: grid;
-  grid-template-columns: 200px 1fr;
-  grid-gap: 1rem;
-  align-items: flex-start;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
This PR implements a number of content updates for the single rustipfs.com page. Each commit describes what it is, but the featured attraction here is the updates to the *Getting Started* section.

My goal with the Getting Started is that I'm trying to emulate the README `ipfs cat` command that is shown after you install and init go-ipfs. I'm open to suggestions about other things we can put for Getting Started, so long as they're roughly this number of lines (or fewer) in length.

As for the code itself, I ran it locally and I _believe it works_, but just needs a bootstrap node to connect to so it can discover the CID in the code.