### PR TITLE
feat: add links to offchain::ipfs and http tutorial

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,6 +169,14 @@ async fn main() {
       <a class="top" href="#">▲</a>
     </section>
 
+    <section id="further-reading">
+      <h2>Further Reading</h2>
+      <p>These are some extra resources to get you started with specific use-cases of Rust IPFS:</p>
+      <p><a href="https://rs-ipfs.github.io/offchain-ipfs-manual/">The offchain::ipfs manual</a>: a project integrating IPFS and Substrate.</p>
+      <!-- TODO: Add link once merged -->
+      <p><a href="">The ipfs-http tutorial</a>: learn how to run and interact with an IPFS node via the HTTP API.</p>
+    </section>
+
     <!--
     <section id="examples">
       <h2>See it in action</h2>

--- a/index.html
+++ b/index.html
@@ -179,6 +179,7 @@ async fn main() {
           <li><a href="https://github.com/rs-ipfs/rust-ipfs/tree/master/http#getting-started">The ipfs-http tutorial</a>: learn how to run and interact with an IPFS node via the HTTP API.</li>
         </ul>
       </div>
+      <a class="top" href="#">▲</a>
     </section>
 
     <!--

--- a/index.html
+++ b/index.html
@@ -4,8 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <title>Rust IPFS</title>
-    <meta name="description" content="The performance and efficiency of Rust, and the decentralized power of IPFS, together at last." />
+    <title>Rust IPFS</title> <meta name="description" content="The performance and efficiency of Rust, and the decentralized power of IPFS, together at last." />
     <meta name="image" content="https://raw.githubusercontent.com/rs-ipfs/rustipfs.com/master/img/open-graph-preview.png">
 
     <!-- Schema.org for Google -->
@@ -175,7 +174,6 @@ async fn main() {
       <div>
         <ul>
           <li><a href="https://rs-ipfs.github.io/offchain-ipfs-manual/">The offchain::ipfs manual</a>: a project integrating IPFS and Substrate.</li>
-          <!-- TODO: Add link once merged -->
           <li><a href="https://github.com/rs-ipfs/rust-ipfs/tree/master/http#getting-started">The ipfs-http tutorial</a>: learn how to run and interact with an IPFS node via the HTTP API.</li>
         </ul>
       </div>

--- a/index.html
+++ b/index.html
@@ -172,9 +172,13 @@ async fn main() {
     <section id="further-reading">
       <h2>Further Reading</h2>
       <p>These are some extra resources to get you started with specific use-cases of Rust IPFS:</p>
-      <p><a href="https://rs-ipfs.github.io/offchain-ipfs-manual/">The offchain::ipfs manual</a>: a project integrating IPFS and Substrate.</p>
-      <!-- TODO: Add link once merged -->
-      <p><a href="">The ipfs-http tutorial</a>: learn how to run and interact with an IPFS node via the HTTP API.</p>
+      <div>
+        <ul>
+          <li><a href="https://rs-ipfs.github.io/offchain-ipfs-manual/">The offchain::ipfs manual</a>: a project integrating IPFS and Substrate.</li>
+          <!-- TODO: Add link once merged -->
+          <li><a href="https://github.com/rs-ipfs/rust-ipfs/tree/master/http#getting-started">The ipfs-http tutorial</a>: learn how to run and interact with an IPFS node via the HTTP API.</li>
+        </ul>
+      </div>
     </section>
 
     <!--

--- a/styles.css
+++ b/styles.css
@@ -252,6 +252,15 @@ a.top {
 .enlighter-n0, .enlighter-n1 { color: #007f7f !important; }
 .enlighter-default { overflow: scroll !important ;}
 
+body > section#further-reading {
+  background: var(--accent2);
+  background-blend-mode: overlay;
+}
+
+body > section#further-reading > p > a {
+  color: var(--logo-dark)
+}
+
 section#support > .logos {
   padding: 2rem 0;
   display: grid;

--- a/styles.css
+++ b/styles.css
@@ -94,6 +94,7 @@ img { max-width: 100%; }
 p { font-size: 1.2rem; }
 a { color: var(--logo-dark); text-decoration: none; font-weight: bold; }
 code { background: var(--value1); font-size: 90%; padding: 0 0.2rem; }
+li { font-size: 1.2rem; }
 
 
 body > header > div, body > section > div {


### PR DESCRIPTION
First quick prototyping, still missing a link for the http tutorial (will be added once merged). Adjusted the link colour to a slightly darker hue for contrast on the green. 

Closes #10.

![Screenshot 2020-10-30 at 16 43 46](https://user-images.githubusercontent.com/13221615/97726153-d8518500-1ac6-11eb-8723-ab22e03e558c.png)
