### PR TITLE
Updating example code to current crate versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,14 +116,16 @@
       </p>
       <pre data-enlighter-language="toml">
 [dependencies]
-ipfs = "0.2.1"
-tokio = { version = "0.2", features = ["full"] }
+ipfs = { git = "https://github.com/rs-ipfs/rust-ipfs" }
+tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1"
       </pre>
       <p>Then, in your <strong>src/main.rs</strong>:</p>
       <pre data-enlighter-language="rust">
 use ipfs::{Ipfs, IpfsOptions, IpfsPath, TestTypes, UninitializedIpfs};
 use std::process::exit;
-use tokio::{io::AsyncWriteExt, stream::StreamExt};
+use tokio::io::AsyncWriteExt;
+use tokio_stream::StreamExt;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
I found that the example code on rustipfs.com was using outdated releases and would not compile anymore. I've updated the crate versions and code as appropriate to get things compiling and running.